### PR TITLE
On many of my networks, I get an explicit ICMP: dest unreach (or auth…

### DIFF
--- a/_returners/splunk_nebula_return.py
+++ b/_returners/splunk_nebula_return.py
@@ -84,7 +84,7 @@ def returner(ret):
                                        timeout=1).text
         aws_account_id = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
                                       timeout=1).json().get('accountId', 'unknown')
-    except (requests.exceptions.ConnectTimeout, ValueError):
+    except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         pass
 

--- a/_returners/splunk_nova_return.py
+++ b/_returners/splunk_nova_return.py
@@ -83,7 +83,7 @@ def returner(ret):
                                        timeout=1).text
         aws_account_id = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
                                       timeout=1).json().get('accountId', 'unknown')
-    except (requests.exceptions.ConnectTimeout, ValueError):
+    except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         pass
 

--- a/_returners/splunk_pulsar_return.py
+++ b/_returners/splunk_pulsar_return.py
@@ -89,7 +89,7 @@ def returner(ret):
                                        timeout=1).text
         aws_account_id = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
                                       timeout=1).json().get('accountId', 'unknown')
-    except (requests.exceptions.ConnectTimeout, ValueError):
+    except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         pass
 


### PR DESCRIPTION
… prohib)

If the connect isn't timed out, it causes the returner to crash, sometimes silently.

```
>>> try:
...     requests.get('http://169.254.169.251/shoot')
... except requests.exceptions.ConnectTimeout:
...     print "lol?"
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/usr/lib/python2.6/site-packages/requests/api.py", line 68, in get
    return request('get', url, **kwargs)
  File "/usr/lib/python2.6/site-packages/requests/api.py", line 50, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.6/site-packages/requests/sessions.py", line 464, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.6/site-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.6/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', error(101, 'Network is unreachable'))

>>> try:
...     requests.get('http://169.254.169.251/shoot')
... except requests.exceptions.RequestException:
...     print "lol?"
...
lol?
```