### PR TITLE
Fixed Nova profile for CentOS 7 - CIS-1.5.1 and CIS-1.5.2

### DIFF
--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1.yaml
@@ -556,7 +556,7 @@ stat:
   grub_conf_own:
     data:
       CentOS Linux-7:
-      - /etc/grub2/grub.cfg:
+      - /boot/grub2/grub.cfg:
           gid: 0
           group: root
           tag: CIS-1.5.1
@@ -566,7 +566,7 @@ stat:
   grub_conf_perm:
     data:
       CentOS Linux-7:
-      - /etc/grub2/grub.cfg:
+      - /boot/grub2/grub.cfg:
           mode: 600
           tag: CIS-1.5.2
     description: Grub must have permissions 600 (Scored)


### PR DESCRIPTION
Updated `/etc/grub2/grub.cfg` to `/boot/grub2/grub.cfg` in the Nova profile `centos-7-level-1-scored-v1.yaml` for CIS-1.5.1 and CIS-1.5.2 according to [CIS_CentOS_Linux_7_Benchmark_v1.1.0.pdf](https://benchmarks.cisecurity.org/tools2/linux/CIS_CentOS_Linux_7_Benchmark_v1.1.0.pdf).

Fix for issue: #47.