### PR TITLE
Always load pulsar, fail silently

### DIFF
--- a/_beacons/pulsar.py
+++ b/_beacons/pulsar.py
@@ -156,6 +156,7 @@ def beacon(config):
     True, then changes will be discarded.
     '''
     if not HAS_PYINOTIFY:
+        log.debug('Not running beacon pulsar. No python-inotify installed.')
         return []
     global CONFIG_STALENESS
     global CONFIG

--- a/_beacons/pulsar.py
+++ b/_beacons/pulsar.py
@@ -50,8 +50,6 @@ log = logging.getLogger(__name__)
 def __virtual__():
     if salt.utils.is_windows():
         return False, 'This module only works on Linux'
-    if HAS_PYINOTIFY:
-        return __virtualname__
     return False
 
 
@@ -157,6 +155,8 @@ def beacon(config):
     If pillar/grains/minion config key `hubblestack:pulsar:maintenance` is set to
     True, then changes will be discarded.
     '''
+    if not HAS_PYINOTIFY:
+        return []
     global CONFIG_STALENESS
     global CONFIG
     if config.get('verbose'):


### PR DESCRIPTION
This should reduce the logs when you have pulsar installed without python-inotify