### PR TITLE
Never settle for 127.x.x.x ip address if you can help it (splunk returners)

### DIFF
--- a/_returners/splunk_nebula_return.py
+++ b/_returners/splunk_nebula_return.py
@@ -91,6 +91,11 @@ def returner(ret):
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
             fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
         if not data:
             return

--- a/_returners/splunk_nova_return.py
+++ b/_returners/splunk_nova_return.py
@@ -90,6 +90,11 @@ def returner(ret):
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
             fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
         if __grains__['master']:
             master = __grains__['master']

--- a/_returners/splunk_pulsar_return.py
+++ b/_returners/splunk_pulsar_return.py
@@ -99,6 +99,11 @@ def returner(ret):
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
             fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
         alerts = []
         for item in data:


### PR DESCRIPTION
On hosts with a misconfigured (or not configured) fqdn, the fqdn_ip4 grain can end up with a useless value in it. Let's not settle for that value.