### PR TITLE
Bugfix errors not being returned

### DIFF
--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -219,7 +219,7 @@ def audit(configs=None,
         results['Messages'] = 'No audits matched this host in the specified profiles.'
 
     for error in ret.get('Error', []):
-      if not terse_results.has_key('Error'):
+      if not results.has_key('Error'):
         results['Errors'] = []
       results['Errors'].append(error)
 

--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -218,6 +218,11 @@ def audit(configs=None,
     if not called_from_top and not results:
         results['Messages'] = 'No audits matched this host in the specified profiles.'
 
+    for error in ret.get('Error', []):
+      if not terse_results.has_key('Error'):
+        results['Errors'] = []
+      results['Errors'].append(error)
+
     return results
 
 def _run_audit(configs, tags, debug):


### PR DESCRIPTION
Again, I was testing the `command` module and incorrectly set my pillar value but never got any kind of return from Salt. Turns out the `Error` key doesn't get processed/returned to the user from what I could see. This could have a knock-on effect in other modules too, but I haven't poked around in them too much yet!

Hopefully this is alright!