### PR TITLE
Removes linux restriction to command.py

### DIFF
--- a/hubblestack_nova/command.py
+++ b/hubblestack_nova/command.py
@@ -82,8 +82,6 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
-        return False, 'This audit module only runs on linux'
     return True
 
 


### PR DESCRIPTION
Hey,

I've tested `command.py` on Windows with no changes and it successfully works, even with the `shell:` parameter in the profile.
 
Unless you know of any issues, it should be good to use on Windows too?

Cheers!