### PR TITLE
Changes all error returns to use dict key 'Errors'

### DIFF
--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -218,8 +218,8 @@ def audit(configs=None,
     if not called_from_top and not results:
         results['Messages'] = 'No audits matched this host in the specified profiles.'
 
-    for error in ret.get('Error', []):
-      if not results.has_key('Error'):
+    for error in ret.get('Errors', []):
+      if not results.has_key('Errors'):
         results['Errors'] = []
       results['Errors'].append(error)
 

--- a/hubblestack_nova/command.py
+++ b/hubblestack_nova/command.py
@@ -106,7 +106,7 @@ def audit(data_list, tags, debug=False):
 
     if __tags__ and not __salt__['config.get']('hubblestack:nova:enable_command_module',
                                                False):
-        ret['Error'] = ['command module has not been explicitly enabled in '
+        ret['Errors'] = ['command module has not been explicitly enabled in '
                         'config. Please set hubblestack:nova:enable_command_module '
                         'to True in pillar or minion config to allow this module.']
         return ret

--- a/hubblestack_nova/misc.py
+++ b/hubblestack_nova/misc.py
@@ -87,9 +87,9 @@ def audit(data_list, tags, debug=False):
 
                 function = FUNCTION_MAP.get(tag_data['function'])
                 if not function:
-                    if 'Error' not in ret:
-                        ret['Error'] = []
-                    ret['Error'].append({tag: 'No function {0} found'
+                    if 'Errors' not in ret:
+                        ret['Errors'] = []
+                    ret['Errors'].append({tag: 'No function {0} found'
                                               .format(tag_data['function'])})
                 args = tag_data.get('args', [])
                 kwargs = tag_data.get('kwargs', {})


### PR DESCRIPTION
Looks like some Nova modules were using the dict key `Error`, but https://github.com/hubblestack/hubble-salt/pull/79 which was merged was looking for `Errors`. Since another key that is returned is `Messages`, I thought it was best to standardise on the plural form.

This should also fix #75 