### PR TITLE
Resolved os_version mismatch.

### DIFF
--- a/hubblestack_nova/cve_scan_v2.py
+++ b/hubblestack_nova/cve_scan_v2.py
@@ -96,9 +96,9 @@ def audit(data_list, tags, debug=False, **kwargs):
     '''
     Main audit function. See module docstring for more information on usage.
     '''
-    os_version = __grains__.get('osrelease', None)
+    os_version = __grains__.get('osmajorrelease', None)
     if os_version is None:
-        os_version = __grains__.get('osmajorrelease', None)
+        os_version = __grains__.get('osrelease', None)
     os_name = __grains__['os'].lower()
 
     log.debug("os_version: %s, os_name: %s", os_version, os_name)
@@ -269,7 +269,7 @@ def _get_cve_vulnerabilities(query_results, os_version):
 
             for pkg in report['_source']['affectedPackage']:
                 #_source:affectedPackages
-                if pkg['OSVersion'] in ['any', os_version]: #Only use matching os
+                if pkg['OSVersion'] in ['any', str(__grains__.get('osmajorrelease', None)), str(__grains__.get('osrelease', None))]: #Only use matching os
                     pkg_obj = VulnerablePkg(title, pkg['packageName'], pkg['packageVersion'], \
                                  score, pkg['operator'], reporter, href, cve_list)
                     if pkg_obj.pkg not in vulnerable_pkgs:

--- a/hubblestack_nova/cve_scan_v2.py
+++ b/hubblestack_nova/cve_scan_v2.py
@@ -96,9 +96,9 @@ def audit(data_list, tags, debug=False, **kwargs):
     '''
     Main audit function. See module docstring for more information on usage.
     '''
-    os_version = __grains__.get('osmajorrelease', None)
+    os_version = __grains__.get('osrelease', None)
     if os_version is None:
-        os_version = __grains__.get('osrelease', None)
+        os_version = __grains__.get('osmajorrelease', None)
     os_name = __grains__['os'].lower()
 
     log.debug("os_version: %s, os_name: %s", os_version, os_name)
@@ -395,4 +395,3 @@ class VulnerablePkg:
             'description': self.title,
             'nova_profile': profile
         }
-


### PR DESCRIPTION
Further resolves https://github.com/hubblestack/hubble/issues/181.

As it turns out, the OSVersion reported from vulners.com in some cases it maps to "osrelease" grain and in others to "osmajorrelease" grain. So compare with both...
Also reverted how os_version is getting value to, first osmajorrelease, then osrelease as it was before https://github.com/hubblestack/hubble-salt/pull/109, just not to break anything else.
Furthermore, when checking OSVersion from vulners stringify the grains' values because it looks like sometimes they are returned as numbers, resulting to nonexistence with 'in'.