### PR TITLE
Disable the win_firewall module on systems that do not support it

### DIFF
--- a/hubblestack_nova/win_firewall.py
+++ b/hubblestack_nova/win_firewall.py
@@ -23,6 +23,8 @@ __virtualname__ = 'win_firewall'
 def __virtual__():
     if not salt.utils.is_windows():
         return False, 'This audit module only runs on windows'
+    if not salt.utils.powershell.module_exists('NetSecurity'):
+        return False, 'This audit module requires the NetSecurity module'
     return True
 
 


### PR DESCRIPTION
Disable win_firewall module on systems that do not have the NetSecurity PowerShell module, such as Windows Server 2008.